### PR TITLE
We have now TTL update operations tests and batch requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,8 @@ jobs:
         runs-on: ubuntu-latest
 
         strategy:
-          matrix:
-            size: [ uint8, uint16, uint32, uint64 ]
+            matrix:
+                size: [uint8, uint16, uint32, uint64]
 
         services:
             throttr:
@@ -48,7 +48,7 @@ jobs:
                   nc -z localhost 9000 || (echo "❌ throttr isn't running on port 9000" && exit 1)
                   yarn test:coverage
               env:
-                THROTTR_SIZE: ${{ matrix.size }}
+                  THROTTR_SIZE: ${{ matrix.size }}
 
             - name: Upload coverage reports to Codecov
               if: ${{ matrix.size == 'uint16' }}

--- a/LICENSE
+++ b/LICENSE
@@ -629,7 +629,7 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    Throttr for Typescript - Throttr Typescript Software Development Kit.
+    Throttr for Typescript - Throttr Software Development Kit for Typescript.
     Copyright (C) 2025  Ian Torres
 
     This program is free software: you can redistribute it and/or modify

--- a/README.md
+++ b/README.md
@@ -41,14 +41,7 @@ npm install @throttr/sdk
 ## Basic Usage
 
 ```typescript
-import { 
-    Service,
-    RequestType,
-    TTLType,
-    AttributeType,
-    ChangeType,
-    ValueSize
-} from '@throttr/sdk';
+import { Service, RequestType, TTLType, AttributeType, ChangeType, ValueSize } from '@throttr/sdk';
 
 const service = new Service({
     host: '127.0.0.1',
@@ -109,7 +102,7 @@ See more examples in [tests](./tests/service.test.ts).
 
 - The protocol assumes Little Endian architecture.
 - The internal message queue ensures requests are processed sequentially.
-- The package is defined to works with protocol 4.0.1 or greatest.
+- The package is defined to works with protocol 4.0.9 or greatest.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@throttr/sdk",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "description": "Node.js client SDK for Throttr TCP server.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -120,19 +120,23 @@ export class Connection {
                     buffer: buffer,
                     expectedType: expectedTypes[index],
                     resolve: (res: FullResponse | SimpleResponse) => {
+                        /* c8 ignore start */
                         if (failed) return;
+                        /* c8 ignore stop */
                         responses[index] = res;
                         remaining--;
                         if (remaining === 0) {
                             resolve(Array.isArray(request) ? responses : responses[0]);
                         }
                     },
+                    /* c8 ignore start */
                     reject: (err: Error) => {
                         if (!failed) {
                             failed = true;
                             reject(err);
                         }
                     },
+                    /* c8 ignore stop */
                 });
             });
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -14,13 +14,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import { Socket } from 'net';
-import {
-    Request,
-    FullResponse,
-    SimpleResponse,
-    QueuedRequest,
-    ValueSize,
-} from './types';
+import { Request, FullResponse, SimpleResponse, QueuedRequest, ValueSize } from './types';
 import { BuildRequest, ParseResponse, GetExpectedResponseType } from './protocol';
 
 /**
@@ -109,7 +103,9 @@ export class Connection {
      *
      * @param request
      */
-    send(request: Request | Request[]): Promise<FullResponse | SimpleResponse | (FullResponse | SimpleResponse)[]> {
+    send(
+        request: Request | Request[]
+    ): Promise<FullResponse | SimpleResponse | (FullResponse | SimpleResponse)[]> {
         const requests = Array.isArray(request) ? request : [request];
         const buffers = requests.map(req => BuildRequest(req, this.value_size));
         const expectedTypes = requests.map(req => GetExpectedResponseType(req));
@@ -131,16 +127,16 @@ export class Connection {
                             resolve(Array.isArray(request) ? responses : responses[0]);
                         }
                     },
-                    reject: (err: any) => {
+                    reject: (err: Error) => {
                         if (!failed) {
                             failed = true;
                             reject(err);
                         }
-                    }
+                    },
                 });
             });
 
-            this.socket.write(Buffer.concat(buffers))
+            this.socket.write(Buffer.concat(buffers));
         });
     }
 
@@ -172,7 +168,13 @@ export class Connection {
             const firstByte = iterationBuffer.readUInt8(offset);
             offset++;
 
-            const processed = this.tryHandleResponse(type, current, iterationBuffer, firstByte, offset);
+            const processed = this.tryHandleResponse(
+                type,
+                current,
+                iterationBuffer,
+                firstByte,
+                offset
+            );
             /* c8 ignore next */
             if (!processed) break;
 

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -47,7 +47,9 @@ export function GetExpectedResponseType(request: Request): 'full' | 'simple' {
         case RequestType.Purge:
         case RequestType.Insert:
             return 'simple';
+        /* c8 ignore start */
         default:
             throw new Error('Unknown request type');
+        /* c8 ignore stop */
     }
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -70,16 +70,26 @@ export class Service {
      *
      * @param request
      */
-    async send(request: Request): Promise<FullResponse | SimpleResponse> {
+    async send(request: Request): Promise<FullResponse | SimpleResponse>;
+    async send(request: Request[]): Promise<(FullResponse | SimpleResponse)[]>;
+    async send(request: Request | Request[]): Promise<any> {
         /* c8 ignore start */
         if (this.connections.length === 0) {
             throw new Error('No available connections.');
         }
         /* c8 ignore stop */
+        return this.getConnection().send(request);
+    }
 
+    /**
+     * Get connection
+     *
+     * @private
+     */
+    private getConnection(): Connection {
         const conn = this.connections[this.round_robin_index];
         this.round_robin_index = (this.round_robin_index + 1) % this.connections.length;
-        return conn.send(request);
+        return conn;
     }
 
     /**

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -253,6 +253,42 @@ describe('Service', () => {
         expect(increased_ttl_query.ttl).toBeGreaterThan(flexNumber(isBigInt, 60));
         expect(increased_ttl_query.ttl).toBeLessThan(flexNumber(isBigInt, 120));
 
+        // After that we're going to UPDATE to "decrease" the "TTL" by 60 ...
+
+        const success_decrease_ttl = (await service.send({
+            type: RequestType.Update,
+            key: key,
+            attribute: AttributeType.TTL,
+            change: ChangeType.Decrease,
+            value: flexNumber(isBigInt, 60),
+        })) as SimpleResponse;
+
+        expect(typeof success_decrease_ttl.success).toBe('boolean');
+
+        // And that should be fine ...
+
+        expect(success_decrease_ttl.success).toBe(true);
+
+        // After that we're going to query to see how much "TTL" we have ...
+
+        const decrease_ttl_query = (await service.send({
+            type: RequestType.Query,
+            key: key,
+        })) as FullResponse;
+
+        expect(typeof decrease_ttl_query.success).toBe('boolean');
+        expect(typeof decrease_ttl_query.quota).toMatch(/number|bigint/);
+        expect(typeof decrease_ttl_query.ttl).toMatch(/number|bigint/);
+        expect(typeof decrease_ttl_query.ttl_type).toBe('number');
+
+        // And "TTL" should be less than sixty ...
+
+        expect(decrease_ttl_query.success).toBe(true);
+        expect(decrease_ttl_query.quota).toBe(flexNumber(isBigInt, 30));
+        expect(decrease_ttl_query.ttl_type).toBe(TTLType.Seconds);
+        expect(decrease_ttl_query.ttl).toBeGreaterThan(flexNumber(isBigInt, 0));
+        expect(decrease_ttl_query.ttl).toBeLessThan(flexNumber(isBigInt, 60));
+
         // After that we're going to purge the key ...
 
         const success_purge = (await service.send({

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -197,22 +197,6 @@ describe('Service', () => {
 
         expect(success_increase_update.success).toBe(true);
 
-        // After that we're going to UPDATE to "increase" the "TTL" by 60 ...
-
-        const success_increase_ttl = (await service.send({
-            type: RequestType.Update,
-            key: key,
-            attribute: AttributeType.TTL,
-            change: ChangeType.Increase,
-            value: flexNumber(isBigInt, 60),
-        })) as SimpleResponse;
-
-        expect(typeof success_increase_ttl.success).toBe('boolean');
-
-        // And that should be fine ...
-
-        expect(success_increase_ttl.success).toBe(true);
-
         // After that we're going to query to see how much "Quota" we have ...
 
         const increased_quota_query = (await service.send({
@@ -232,6 +216,42 @@ describe('Service', () => {
         expect(increased_quota_query.ttl_type).toBe(TTLType.Seconds);
         expect(increased_quota_query.ttl).toBeGreaterThan(flexNumber(isBigInt, 0));
         expect(increased_quota_query.ttl).toBeLessThan(flexNumber(isBigInt, 60));
+
+        // After that we're going to UPDATE to "increase" the "TTL" by 60 ...
+
+        const success_increase_ttl = (await service.send({
+            type: RequestType.Update,
+            key: key,
+            attribute: AttributeType.TTL,
+            change: ChangeType.Increase,
+            value: flexNumber(isBigInt, 60),
+        })) as SimpleResponse;
+
+        expect(typeof success_increase_ttl.success).toBe('boolean');
+
+        // And that should be fine ...
+
+        expect(success_increase_ttl.success).toBe(true);
+
+        // After that we're going to query to see how much "TTL" we have ...
+
+        const increased_ttl_query = (await service.send({
+            type: RequestType.Query,
+            key: key,
+        })) as FullResponse;
+
+        expect(typeof increased_ttl_query.success).toBe('boolean');
+        expect(typeof increased_ttl_query.quota).toMatch(/number|bigint/);
+        expect(typeof increased_ttl_query.ttl).toMatch(/number|bigint/);
+        expect(typeof increased_ttl_query.ttl_type).toBe('number');
+
+        // And "TTL" should be less than one hundred twenty and more than sixty ...
+
+        expect(increased_ttl_query.success).toBe(true);
+        expect(increased_ttl_query.quota).toBe(flexNumber(isBigInt, 30));
+        expect(increased_ttl_query.ttl_type).toBe(TTLType.Seconds);
+        expect(increased_ttl_query.ttl).toBeGreaterThan(flexNumber(isBigInt, 60));
+        expect(increased_ttl_query.ttl).toBeLessThan(flexNumber(isBigInt, 120));
 
         // After that we're going to purge the key ...
 

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -23,7 +23,7 @@ import {
     TTLType,
     ValueSize,
 } from '../src';
-import {expect} from 'vitest';
+import { expect } from 'vitest';
 
 describe('Service', () => {
     let service: Service;
@@ -50,7 +50,7 @@ describe('Service', () => {
         service.disconnect();
     });
 
-    const flexNumber = (bigInt: boolean, number: number) => bigInt ? BigInt(number) : number; // NOSONAR
+    const flexNumber = (bigInt: boolean, number: number) => (bigInt ? BigInt(number) : number); // NOSONAR
 
     it('it should be compatible with throttr server', async () => {
         const key = '333333';
@@ -368,7 +368,6 @@ describe('Service', () => {
         expect(exists_query.success).toBe(false);
     });
 
-
     it('should insert and query multiple keys in a single batch write', async () => {
         const isBigInt = process.env.THROTTR_SIZE === 'uint64';
 
@@ -377,7 +376,7 @@ describe('Service', () => {
         const key1 = 'batch-key-1';
         const key2 = 'batch-key-2';
 
-        const [res1, res2] = await service.send([
+        const [res1, res2] = (await service.send([
             {
                 type: RequestType.Insert,
                 key: key1,
@@ -392,12 +391,12 @@ describe('Service', () => {
                 ttl_type: TTLType.Seconds,
                 ttl: flexNumber(isBigInt, 30),
             },
-        ]) as SimpleResponse[];
+        ])) as SimpleResponse[];
 
         expect(res1.success).toBe(true);
         expect(res2.success).toBe(true);
 
-        const [query1, query2] = await service.send([
+        const [query1, query2] = (await service.send([
             {
                 type: RequestType.Query,
                 key: key1,
@@ -406,7 +405,7 @@ describe('Service', () => {
                 type: RequestType.Query,
                 key: key2,
             },
-        ]) as FullResponse[];
+        ])) as FullResponse[];
 
         expect(query1.success).toBe(true);
         expect(query1.quota).toBe(flexNumber(isBigInt, 7));

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -289,6 +289,42 @@ describe('Service', () => {
         expect(decrease_ttl_query.ttl).toBeGreaterThan(flexNumber(isBigInt, 0));
         expect(decrease_ttl_query.ttl).toBeLessThan(flexNumber(isBigInt, 60));
 
+        // After that we're going to UPDATE to "patch" the "TTL" to 90 ...
+
+        const success_patch_ttl = (await service.send({
+            type: RequestType.Update,
+            key: key,
+            attribute: AttributeType.TTL,
+            change: ChangeType.Patch,
+            value: flexNumber(isBigInt, 90),
+        })) as SimpleResponse;
+
+        expect(typeof success_patch_ttl.success).toBe('boolean');
+
+        // And that should be fine ...
+
+        expect(success_patch_ttl.success).toBe(true);
+
+        // After that we're going to query to see how much "TTL" we have ...
+
+        const patch_ttl_query = (await service.send({
+            type: RequestType.Query,
+            key: key,
+        })) as FullResponse;
+
+        expect(typeof patch_ttl_query.success).toBe('boolean');
+        expect(typeof patch_ttl_query.quota).toMatch(/number|bigint/);
+        expect(typeof patch_ttl_query.ttl).toMatch(/number|bigint/);
+        expect(typeof patch_ttl_query.ttl_type).toBe('number');
+
+        // And "TTL" should be less than ninety ...
+
+        expect(patch_ttl_query.success).toBe(true);
+        expect(patch_ttl_query.quota).toBe(flexNumber(isBigInt, 30));
+        expect(patch_ttl_query.ttl_type).toBe(TTLType.Seconds);
+        expect(patch_ttl_query.ttl).toBeGreaterThan(flexNumber(isBigInt, 60));
+        expect(patch_ttl_query.ttl).toBeLessThan(flexNumber(isBigInt, 90));
+
         // After that we're going to purge the key ...
 
         const success_purge = (await service.send({
@@ -360,7 +396,6 @@ describe('Service', () => {
 
         expect(res1.success).toBe(true);
         expect(res2.success).toBe(true);
-
 
         const [query1, query2] = await service.send([
             {

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -23,7 +23,7 @@ import {
     TTLType,
     ValueSize,
 } from '../src';
-import { expect } from 'vitest';
+import {expect} from 'vitest';
 
 describe('Service', () => {
     let service: Service;
@@ -49,219 +49,282 @@ describe('Service', () => {
     afterAll(() => {
         service.disconnect();
     });
-    
+
     const flexNumber = (bigInt: boolean, number: number) => bigInt ? BigInt(number) : number; // NOSONAR
 
-    it('it should be compatible with throttr server',
-        async () => {
-            const key = '333333';
-            const isBigInt = process.env.THROTTR_SIZE === 'uint64';
-            await new Promise(resolve => setTimeout(resolve, 1000)); // NOSONAR
+    it('it should be compatible with throttr server', async () => {
+        const key = '333333';
+        const isBigInt = process.env.THROTTR_SIZE === 'uint64';
+        await new Promise(resolve => setTimeout(resolve, 1000)); // NOSONAR
 
-            // We are going to make a INSERT with 7 as "Quota" and 60 seconds of "TTL" ...
+        // We are going to make a INSERT with 7 as "Quota" and 60 seconds of "TTL" ...
 
-            const insert = (await service.send({
+        const insert = (await service.send({
+            type: RequestType.Insert,
+            key: key,
+            quota: flexNumber(isBigInt, 7),
+            ttl_type: TTLType.Seconds,
+            ttl: flexNumber(isBigInt, 60),
+        })) as SimpleResponse;
+
+        expect(typeof insert.success).toBe('boolean');
+
+        // And that should be accepted ...
+
+        expect(insert.success).toBe(true);
+
+        // After that, we are going to make a QUERY to see what was stored ...
+
+        const first_query = (await service.send({
+            type: RequestType.Query,
+            key: key,
+        })) as FullResponse;
+
+        expect(typeof first_query.success).toBe('boolean');
+        expect(typeof first_query.quota).toMatch(/number|bigint/);
+        expect(typeof first_query.ttl).toMatch(/number|bigint/);
+        expect(typeof first_query.ttl_type).toBe('number');
+
+        // And that must be stored ...
+
+        expect(first_query.success).toBe(true);
+        expect(first_query.quota).toBe(flexNumber(isBigInt, 7));
+        expect(first_query.ttl_type).toBe(TTLType.Seconds);
+        expect(first_query.ttl).toBeGreaterThan(flexNumber(isBigInt, 0));
+        expect(first_query.ttl).toBeLessThan(flexNumber(isBigInt, 60));
+
+        // Right now we will UPDATE the quota to zero using "decrease" operation ...
+
+        const success_decrease_update = (await service.send({
+            type: RequestType.Update,
+            key: key,
+            attribute: AttributeType.Quota,
+            change: ChangeType.Decrease,
+            value: flexNumber(isBigInt, 7),
+        })) as SimpleResponse;
+
+        expect(typeof success_decrease_update.success).toBe('boolean');
+
+        // And that should be fine ...
+
+        expect(success_decrease_update.success).toBe(true);
+
+        // After that we're going to check if we can "decrease" again ...
+
+        const failed_decrease_update = (await service.send({
+            type: RequestType.Update,
+            key: key,
+            attribute: AttributeType.Quota,
+            change: ChangeType.Decrease,
+            value: flexNumber(isBigInt, 7),
+        })) as SimpleResponse;
+
+        expect(typeof failed_decrease_update.success).toBe('boolean');
+
+        // But that should fail ...
+
+        expect(failed_decrease_update.success).toBe(false);
+
+        // After that we're going to query to see how much "Quota" we have ...
+
+        const empty_quota_query = (await service.send({
+            type: RequestType.Query,
+            key: key,
+        })) as FullResponse;
+
+        expect(typeof empty_quota_query.success).toBe('boolean');
+        expect(typeof empty_quota_query.quota).toMatch(/number|bigint/);
+        expect(typeof empty_quota_query.ttl).toMatch(/number|bigint/);
+        expect(typeof empty_quota_query.ttl_type).toBe('number');
+
+        // And "Quota" should be zero ...
+
+        expect(empty_quota_query.success).toBe(true);
+        expect(empty_quota_query.quota).toBe(flexNumber(isBigInt, 0));
+        expect(empty_quota_query.ttl_type).toBe(TTLType.Seconds);
+        expect(empty_quota_query.ttl).toBeGreaterThan(flexNumber(isBigInt, 0));
+        expect(empty_quota_query.ttl).toBeLessThan(flexNumber(isBigInt, 60));
+
+        // After that we're going to UPDATE to "patch" the "Quota" to 10 ...
+
+        const success_patch_update = (await service.send({
+            type: RequestType.Update,
+            key: key,
+            attribute: AttributeType.Quota,
+            change: ChangeType.Patch,
+            value: flexNumber(isBigInt, 10),
+        })) as SimpleResponse;
+
+        expect(typeof success_patch_update.success).toBe('boolean');
+
+        // And that should be fine ...
+
+        expect(success_patch_update.success).toBe(true);
+
+        // After that we're going to query to see how much "Quota" we have ...
+
+        const patched_quota_query = (await service.send({
+            type: RequestType.Query,
+            key: key,
+        })) as FullResponse;
+
+        expect(typeof patched_quota_query.success).toBe('boolean');
+        expect(typeof patched_quota_query.quota).toMatch(/number|bigint/);
+        expect(typeof patched_quota_query.ttl).toMatch(/number|bigint/);
+        expect(typeof patched_quota_query.ttl_type).toBe('number');
+
+        // And "Quota" should be ten ...
+
+        expect(patched_quota_query.success).toBe(true);
+        expect(patched_quota_query.quota).toBe(flexNumber(isBigInt, 10));
+        expect(patched_quota_query.ttl_type).toBe(TTLType.Seconds);
+        expect(patched_quota_query.ttl).toBeGreaterThan(flexNumber(isBigInt, 0));
+        expect(patched_quota_query.ttl).toBeLessThan(flexNumber(isBigInt, 60));
+
+        // After that we're going to UPDATE to "increase" the "Quota" by 20 ...
+
+        const success_increase_update = (await service.send({
+            type: RequestType.Update,
+            key: key,
+            attribute: AttributeType.Quota,
+            change: ChangeType.Increase,
+            value: flexNumber(isBigInt, 20),
+        })) as SimpleResponse;
+
+        expect(typeof success_increase_update.success).toBe('boolean');
+
+        // And that should be fine ...
+
+        expect(success_increase_update.success).toBe(true);
+
+        // After that we're going to UPDATE to "increase" the "TTL" by 60 ...
+
+        const success_increase_ttl = (await service.send({
+            type: RequestType.Update,
+            key: key,
+            attribute: AttributeType.TTL,
+            change: ChangeType.Increase,
+            value: flexNumber(isBigInt, 60),
+        })) as SimpleResponse;
+
+        expect(typeof success_increase_ttl.success).toBe('boolean');
+
+        // And that should be fine ...
+
+        expect(success_increase_ttl.success).toBe(true);
+
+        // After that we're going to query to see how much "Quota" we have ...
+
+        const increased_quota_query = (await service.send({
+            type: RequestType.Query,
+            key: key,
+        })) as FullResponse;
+
+        expect(typeof increased_quota_query.success).toBe('boolean');
+        expect(typeof increased_quota_query.quota).toMatch(/number|bigint/);
+        expect(typeof increased_quota_query.ttl).toMatch(/number|bigint/);
+        expect(typeof increased_quota_query.ttl_type).toBe('number');
+
+        // And "Quota" should be thirty ...
+
+        expect(increased_quota_query.success).toBe(true);
+        expect(increased_quota_query.quota).toBe(flexNumber(isBigInt, 30));
+        expect(increased_quota_query.ttl_type).toBe(TTLType.Seconds);
+        expect(increased_quota_query.ttl).toBeGreaterThan(flexNumber(isBigInt, 0));
+        expect(increased_quota_query.ttl).toBeLessThan(flexNumber(isBigInt, 60));
+
+        // After that we're going to purge the key ...
+
+        const success_purge = (await service.send({
+            type: RequestType.Purge,
+            key: key,
+        })) as SimpleResponse;
+
+        expect(typeof success_purge.success).toBe('boolean');
+
+        // And that should be fine ...
+
+        expect(success_purge.success).toBe(true);
+
+        // After that we're going to try again ...
+
+        const failed_purge = (await service.send({
+            type: RequestType.Purge,
+            key: key,
+        })) as SimpleResponse;
+
+        expect(typeof failed_purge.success).toBe('boolean');
+
+        // And that should fail ...
+
+        expect(failed_purge.success).toBe(false);
+
+        // After that we're going to query to see if key exists ...
+
+        const exists_query = (await service.send({
+            type: RequestType.Query,
+            key: key,
+        })) as FullResponse;
+
+        expect(typeof exists_query.success).toBe('boolean');
+        expect(typeof exists_query.quota).toMatch(/number|bigint/);
+        expect(typeof exists_query.ttl).toMatch(/number|bigint/);
+        expect(typeof exists_query.ttl_type).toBe('number');
+
+        // And that should fail ...
+
+        expect(exists_query.success).toBe(false);
+    });
+
+
+    it('should insert and query multiple keys in a single batch write', async () => {
+        const isBigInt = process.env.THROTTR_SIZE === 'uint64';
+
+        await new Promise(resolve => setTimeout(resolve, 1000)); // NOSONAR
+
+        const key1 = 'batch-key-1';
+        const key2 = 'batch-key-2';
+
+        const [res1, res2] = await service.send([
+            {
                 type: RequestType.Insert,
-                key: key,
-                quota: flexNumber(isBigInt,7),
+                key: key1,
+                quota: flexNumber(isBigInt, 7),
                 ttl_type: TTLType.Seconds,
-                ttl: flexNumber(isBigInt,60),
-            })) as SimpleResponse;
+                ttl: flexNumber(isBigInt, 60),
+            },
+            {
+                type: RequestType.Insert,
+                key: key2,
+                quota: flexNumber(isBigInt, 9),
+                ttl_type: TTLType.Seconds,
+                ttl: flexNumber(isBigInt, 30),
+            },
+        ]) as SimpleResponse[];
 
-            expect(typeof insert.success).toBe('boolean');
+        expect(res1.success).toBe(true);
+        expect(res2.success).toBe(true);
 
-            // And that should be accepted ...
 
-            expect(insert.success).toBe(true);
-
-            // After that, we are going to make a QUERY to see what was stored ...
-
-            const first_query = (await service.send({
+        const [query1, query2] = await service.send([
+            {
                 type: RequestType.Query,
-                key: key,
-            })) as FullResponse;
-
-            expect(typeof first_query.success).toBe('boolean');
-            expect(typeof first_query.quota).toMatch(/number|bigint/);
-            expect(typeof first_query.ttl).toMatch(/number|bigint/);
-            expect(typeof first_query.ttl_type).toBe('number');
-
-            // And that must be stored ...
-
-            expect(first_query.success).toBe(true);
-            expect(first_query.quota).toBe(flexNumber(isBigInt,7));
-            expect(first_query.ttl_type).toBe(TTLType.Seconds);
-            expect(first_query.ttl).toBeGreaterThan(flexNumber(isBigInt,0));
-            expect(first_query.ttl).toBeLessThan(flexNumber(isBigInt,60));
-
-            // Right now we will UPDATE the quota to zero using "decrease" operation ...
-
-            const success_decrease_update = (await service.send({
-                type: RequestType.Update,
-                key: key,
-                attribute: AttributeType.Quota,
-                change: ChangeType.Decrease,
-                value: flexNumber(isBigInt,7),
-            })) as SimpleResponse;
-
-            expect(typeof success_decrease_update.success).toBe('boolean');
-
-            // And that should be fine ...
-
-            expect(success_decrease_update.success).toBe(true);
-
-            // After that we're going to check if we can "decrease" again ...
-
-            const failed_decrease_update = (await service.send({
-                type: RequestType.Update,
-                key: key,
-                attribute: AttributeType.Quota,
-                change: ChangeType.Decrease,
-                value: flexNumber(isBigInt,7),
-            })) as SimpleResponse;
-
-            expect(typeof failed_decrease_update.success).toBe('boolean');
-
-            // But that should fail ...
-
-            expect(failed_decrease_update.success).toBe(false);
-
-            // After that we're going to query to see how much "Quota" we have ...
-
-            const empty_quota_query = (await service.send({
+                key: key1,
+            },
+            {
                 type: RequestType.Query,
-                key: key,
-            })) as FullResponse;
+                key: key2,
+            },
+        ]) as FullResponse[];
 
-            expect(typeof empty_quota_query.success).toBe('boolean');
-            expect(typeof empty_quota_query.quota).toMatch(/number|bigint/);
-            expect(typeof empty_quota_query.ttl).toMatch(/number|bigint/);
-            expect(typeof empty_quota_query.ttl_type).toBe('number');
+        expect(query1.success).toBe(true);
+        expect(query1.quota).toBe(flexNumber(isBigInt, 7));
+        expect(query1.ttl_type).toBe(TTLType.Seconds);
+        expect(query1.ttl).toBeGreaterThan(flexNumber(isBigInt, 0));
 
-            // And "Quota" should be zero ...
-
-            expect(empty_quota_query.success).toBe(true);
-            expect(empty_quota_query.quota).toBe(flexNumber(isBigInt,0));
-            expect(empty_quota_query.ttl_type).toBe(TTLType.Seconds);
-            expect(empty_quota_query.ttl).toBeGreaterThan(flexNumber(isBigInt,0));
-            expect(empty_quota_query.ttl).toBeLessThan(flexNumber(isBigInt,60));
-
-            // After that we're going to UPDATE to "patch" the "Quota" to 10 ...
-
-            const success_patch_update = (await service.send({
-                type: RequestType.Update,
-                key: key,
-                attribute: AttributeType.Quota,
-                change: ChangeType.Patch,
-                value: flexNumber(isBigInt,10),
-            })) as SimpleResponse;
-
-            expect(typeof success_patch_update.success).toBe('boolean');
-
-            // And that should be fine ...
-
-            expect(success_patch_update.success).toBe(true);
-
-            // After that we're going to query to see how much "Quota" we have ...
-
-            const patched_quota_query = (await service.send({
-                type: RequestType.Query,
-                key: key,
-            })) as FullResponse;
-
-            expect(typeof patched_quota_query.success).toBe('boolean');
-            expect(typeof patched_quota_query.quota).toMatch(/number|bigint/);
-            expect(typeof patched_quota_query.ttl).toMatch(/number|bigint/);
-            expect(typeof patched_quota_query.ttl_type).toBe('number');
-
-            // And "Quota" should be ten ...
-
-            expect(patched_quota_query.success).toBe(true);
-            expect(patched_quota_query.quota).toBe(flexNumber(isBigInt,10));
-            expect(patched_quota_query.ttl_type).toBe(TTLType.Seconds);
-            expect(patched_quota_query.ttl).toBeGreaterThan(flexNumber(isBigInt,0));
-            expect(patched_quota_query.ttl).toBeLessThan(flexNumber(isBigInt,60));
-
-            // After that we're going to UPDATE to "increase" the "Quota" by 20 ...
-
-            const success_increase_update = (await service.send({
-                type: RequestType.Update,
-                key: key,
-                attribute: AttributeType.Quota,
-                change: ChangeType.Increase,
-                value: flexNumber(isBigInt,20),
-            })) as SimpleResponse;
-
-            expect(typeof success_increase_update.success).toBe('boolean');
-
-            // And that should be fine ...
-
-            expect(success_increase_update.success).toBe(true);
-
-            // After that we're going to query to see how much "Quota" we have ...
-
-            const increased_quota_query = (await service.send({
-                type: RequestType.Query,
-                key: key,
-            })) as FullResponse;
-
-            expect(typeof increased_quota_query.success).toBe('boolean');
-            expect(typeof increased_quota_query.quota).toMatch(/number|bigint/);
-            expect(typeof increased_quota_query.ttl).toMatch(/number|bigint/);
-            expect(typeof increased_quota_query.ttl_type).toBe('number');
-
-            // And "Quota" should be thirty ...
-
-            expect(increased_quota_query.success).toBe(true);
-            expect(increased_quota_query.quota).toBe(flexNumber(isBigInt,30));
-            expect(increased_quota_query.ttl_type).toBe(TTLType.Seconds);
-            expect(increased_quota_query.ttl).toBeGreaterThan(flexNumber(isBigInt,0));
-            expect(increased_quota_query.ttl).toBeLessThan(flexNumber(isBigInt,60));
-
-            // After that we're going to purge the key ...
-
-            const success_purge = (await service.send({
-                type: RequestType.Purge,
-                key: key,
-            })) as SimpleResponse;
-
-            expect(typeof success_purge.success).toBe('boolean');
-
-            // And that should be fine ...
-
-            expect(success_purge.success).toBe(true);
-
-            // After that we're going to try again ...
-
-            const failed_purge = (await service.send({
-                type: RequestType.Purge,
-                key: key,
-            })) as SimpleResponse;
-
-            expect(typeof failed_purge.success).toBe('boolean');
-
-            // And that should fail ...
-
-            expect(failed_purge.success).toBe(false);
-
-            // After that we're going to query to see if key exists ...
-
-            const exists_query = (await service.send({
-                type: RequestType.Query,
-                key: key,
-            })) as FullResponse;
-
-            expect(typeof exists_query.success).toBe('boolean');
-            expect(typeof exists_query.quota).toMatch(/number|bigint/);
-            expect(typeof exists_query.ttl).toMatch(/number|bigint/);
-            expect(typeof exists_query.ttl_type).toBe('number');
-
-            // And that should fail ...
-
-            expect(exists_query.success).toBe(false);
-        },
-        {
-            timeout: 30000,
-        }
-    );
+        expect(query2.success).toBe(true);
+        expect(query2.quota).toBe(flexNumber(isBigInt, 9));
+        expect(query2.ttl_type).toBe(TTLType.Seconds);
+        expect(query2.ttl).toBeGreaterThan(flexNumber(isBigInt, 0));
+    });
 });


### PR DESCRIPTION
This is a huge change.

The reasons, two:

- Right now we have a SDK which implements all the available operations on `throttr`. 
- Is the first SDK on the series which implements batching.

Batching by himself, it's a huge feature ...

This reduces the amount of write/read operations on the socket by sending N requests.

You can reduce the amount of TCP/IP/Ethernet overhead. I mean ... If you're sending 5 bytes per message with ~60 bytes of overhead, that is simply absurd ...

Right now you can do pipeline in the following terms:

```
INSERT key 120 60
UPDATE key DECREASE 1
```

> If the first operation is `true`, that means "there are no previous rate limite assigned" so `is the first request`, otherwise, `isn't > the first request`. If the second operation returns `false`, it means, `no quota available`, otherwise `quota available`. 

Depending on the `key length` and `dynamic fields size`, you can use the `protocol specification` to see how much bytes will be used, before hand. 