### PR TITLE
Supporting protocol 5.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
         services:
             throttr:
-                image: ghcr.io/throttr/throttr:4.0.11-debug-${{ matrix.size }}
+                image: ghcr.io/throttr/throttr:4.0.14-debug-${{ matrix.size }}
                 ports:
                     - 9000:9000
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ await service.send({
 ### As in-memory database
 
 ```typescript
-const key = "json-storage";
+const key = 'json-storage';
 
 // Set arbitrary data into the storage
 const set_response = await service.send({
@@ -106,7 +106,7 @@ const set_response = await service.send({
     key: key,
     ttl_type: TTLType.Hours,
     ttl: 24,
-    value: "EHLO",
+    value: 'EHLO',
 });
 
 // Get from the memory
@@ -115,7 +115,7 @@ const get_response = await service.send({
     key: key,
 });
 
-console.log("Data: ", get_response.value) // Must be "EHLO"
+console.log('Data: ', get_response.value); // Must be "EHLO"
 
 // Optionally, purge the key
 await service.send({

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ See more examples in [tests](./tests/service.test.ts).
 
 - The protocol assumes Little Endian architecture.
 - The internal message queue ensures requests are processed sequentially.
-- The package is defined to works with protocol 4.0.11 or greatest.
+- The package is defined to works with protocol 4.0.14 or greatest.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ npm install @throttr/sdk
 
 ## Basic Usage
 
+### As Rate Limiter
+
 ```typescript
 import { Service, RequestType, TTLType, AttributeType, ChangeType, ValueSize } from '@throttr/sdk';
 
@@ -87,6 +89,35 @@ console.log('TTL Type:', query_response.ttl_type);
 console.log('TTL:', query_response.ttl);
 
 // Optionally, purge the quota
+await service.send({
+    type: RequestType.Purge,
+    key: key,
+});
+```
+
+### As in-memory database
+
+```typescript
+const key = "json-storage";
+
+// Set arbitrary data into the storage
+const set_response = await service.send({
+    type: RequestType.Set,
+    key: key,
+    ttl_type: TTLType.Hours,
+    ttl: 24,
+    value: "EHLO",
+});
+
+// Get from the memory
+const get_response = await service.send({
+    type: RequestType.Get,
+    key: key,
+});
+
+console.log("Data: ", get_response.value) // Must be "EHLO"
+
+// Optionally, purge the key
 await service.send({
     type: RequestType.Purge,
     key: key,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@throttr/sdk",
-    "version": "3.0.4",
+    "version": "4.0.0",
     "description": "Node.js client SDK for Throttr TCP server.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -239,8 +239,16 @@ export class Connection {
             const valueSize = read(buffer, 2 + this.value_size, this.value_size);
             if (buffer.length < offset - 1 + expectedLength + Number(valueSize)) return false;
 
-            const slice = buffer.subarray(offset - 1, offset - 1 + expectedLength + Number(valueSize));
-            return this.tryParse(slice, type, current, offset - 1 + expectedLength + Number(valueSize));
+            const slice = buffer.subarray(
+                offset - 1,
+                offset - 1 + expectedLength + Number(valueSize)
+            );
+            return this.tryParse(
+                slice,
+                type,
+                current,
+                offset - 1 + expectedLength + Number(valueSize)
+            );
         }
 
         return false;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -236,11 +236,11 @@ export class Connection {
             /* c8 ignore next */
             if (buffer.length < offset - 1 + expectedLength) return false;
 
-            const valueSize = read(buffer, 2 + this.value_size, this.value_size) as number;
-            if (buffer.length < offset - 1 + expectedLength + valueSize) return false;
+            const valueSize = read(buffer, 2 + this.value_size, this.value_size);
+            if (buffer.length < offset - 1 + expectedLength + Number(valueSize)) return false;
 
-            const slice = buffer.subarray(offset - 1, offset - 1 + expectedLength + valueSize);
-            return this.tryParse(slice, type, current, offset - 1 + expectedLength + valueSize);
+            const slice = buffer.subarray(offset - 1, offset - 1 + expectedLength + Number(valueSize));
+            return this.tryParse(slice, type, current, offset - 1 + expectedLength + Number(valueSize));
         }
 
         return false;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -104,9 +104,7 @@ export class Connection {
      *
      * @param request
      */
-    send(
-        request: Request | Request[]
-    ): Promise<Response | Response[]> {
+    send(request: Request | Request[]): Promise<Response | Response[]> {
         const requests = Array.isArray(request) ? request : [request];
         const buffers = requests.map(req => BuildRequest(req, this.value_size));
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -110,8 +110,6 @@ export class Connection {
         const requests = Array.isArray(request) ? request : [request];
         const buffers = requests.map(req => BuildRequest(req, this.value_size));
 
-        console.log(buffers.map((buffer) => console.log(buffer.toString('hex'))))
-
         const expectedTypes = requests.map(req => GetExpectedResponseType(req));
 
         return new Promise((resolve, reject) => {
@@ -236,8 +234,6 @@ export class Connection {
                 return this.tryParse(slice, type, current, offset);
             }
 
-            console.log("GET buffer", buffer.toString('hex'));
-
             const expectedLength = this.value_size * 2 + 2;
             /* c8 ignore next */
             if (buffer.length < offset - 1 + expectedLength) return false;
@@ -246,7 +242,7 @@ export class Connection {
             if (buffer.length < offset - 1 + expectedLength + valueSize) return false;
 
             const slice = buffer.subarray(offset - 1, offset - 1 + expectedLength + valueSize);
-            return this.tryParse(slice, type, current, offset - 1 + expectedLength);
+            return this.tryParse(slice, type, current, offset - 1 + expectedLength + valueSize);
         }
 
         return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,12 @@
 
 export { Service } from './service';
 export { RequestType, TTLType, AttributeType, ChangeType, ValueSize } from './types';
-export type { Request, QueryResponse, GetResponse, StatusResponse, SimpleResponse, FullResponse, StorageResponse } from './types';
+export type {
+    Request,
+    QueryResponse,
+    GetResponse,
+    StatusResponse,
+    SimpleResponse,
+    FullResponse,
+    StorageResponse,
+} from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,4 @@
 
 export { Service } from './service';
 export { RequestType, TTLType, AttributeType, ChangeType, ValueSize } from './types';
-export type { Request, FullResponse, SimpleResponse } from './types';
+export type { Request, QueryResponse, StatusResponse } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,4 @@
 
 export { Service } from './service';
 export { RequestType, TTLType, AttributeType, ChangeType, ValueSize } from './types';
-export type { Request, QueryResponse, StatusResponse } from './types';
+export type { Request, QueryResponse, GetResponse, StatusResponse, SimpleResponse, FullResponse, StorageResponse } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,4 @@ export type {
     QueryResponse,
     GetResponse,
     StatusResponse,
-    SimpleResponse,
-    FullResponse,
-    StorageResponse,
 } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,4 @@
 
 export { Service } from './service';
 export { RequestType, TTLType, AttributeType, ChangeType, ValueSize } from './types';
-export type {
-    Request,
-    QueryResponse,
-    GetResponse,
-    StatusResponse,
-} from './types';
+export type { Request, QueryResponse, GetResponse, StatusResponse } from './types';

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {Request, RequestType, ResponseType, ValueSize} from './types';
-import {parseResponse, serializeRequest} from './utils';
+import { Request, RequestType, ResponseType, ValueSize } from './types';
+import { parseResponse, serializeRequest } from './utils';
 
 /**
  * Build request

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import { Request, RequestType, ValueSize } from './types';
-import { serializeRequest, parseResponse } from './utils';
+import {Request, RequestType, ResponseType, ValueSize} from './types';
+import {parseResponse, serializeRequest} from './utils';
 
 /**
  * Build request
@@ -30,7 +30,7 @@ export const BuildRequest = serializeRequest;
  * @param expected
  * @param value_size
  */
-export function ParseResponse(buffer: Buffer, expected: 'full' | 'simple', value_size: ValueSize) {
+export function ParseResponse(buffer: Buffer, expected: ResponseType, value_size: ValueSize) {
     return parseResponse(buffer, expected, value_size);
 }
 
@@ -39,14 +39,17 @@ export function ParseResponse(buffer: Buffer, expected: 'full' | 'simple', value
  *
  * @param request
  */
-export function GetExpectedResponseType(request: Request): 'full' | 'simple' {
+export function GetExpectedResponseType(request: Request): ResponseType {
     switch (request.type) {
-        case RequestType.Query:
-            return 'full';
         case RequestType.Update:
         case RequestType.Purge:
         case RequestType.Insert:
-            return 'simple';
+        case RequestType.Set:
+            return 'status';
+        case RequestType.Query:
+            return 'query';
+        case RequestType.Get:
+            return 'get';
         /* c8 ignore start */
         default:
             throw new Error('Unknown request type');

--- a/src/service.ts
+++ b/src/service.ts
@@ -71,7 +71,7 @@ export class Service {
      * @param request
      */
     async send(request: Request): Promise<Response>;
-    async send(request: Request[]): Promise<(Response)[]>;
+    async send(request: Request[]): Promise<Response[]>;
     async send(request: Request | Request[]): Promise<any> {
         /* c8 ignore start */
         if (this.connections.length === 0) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import { Configuration, Request, FullResponse, SimpleResponse } from './types';
+import { Configuration, Request, Response } from './types';
 import { Connection } from './connection';
 
 /**
@@ -70,8 +70,8 @@ export class Service {
      *
      * @param request
      */
-    async send(request: Request): Promise<FullResponse | SimpleResponse>;
-    async send(request: Request[]): Promise<(FullResponse | SimpleResponse)[]>;
+    async send(request: Request): Promise<Response>;
+    async send(request: Request[]): Promise<(Response)[]>;
     async send(request: Request | Request[]): Promise<any> {
         /* c8 ignore start */
         if (this.connections.length === 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -407,3 +407,10 @@ export interface QueuedRequest {
      */
     expectedType: ResponseType;
 }
+
+/**
+ * Backward compatibility interfaces
+ */
+export type SimpleResponse = StatusResponse;
+export type FullResponse = QueryResponse;
+export type StorageResponse = GetResponse;

--- a/src/types.ts
+++ b/src/types.ts
@@ -412,10 +412,3 @@ export interface QueuedRequest {
      */
     expectedType: ResponseType;
 }
-
-/**
- * Backward compatibility interfaces
- */
-export type SimpleResponse = StatusResponse;
-export type FullResponse = QueryResponse;
-export type StorageResponse = GetResponse;

--- a/src/types.ts
+++ b/src/types.ts
@@ -273,7 +273,6 @@ export interface GetRequest {
     key: string;
 }
 
-
 /**
  * Get request
  */
@@ -307,7 +306,13 @@ export interface SetRequest {
 /**
  * Request
  */
-export type Request = InsertRequest | QueryRequest | PurgeRequest | UpdateRequest | SetRequest | GetRequest;
+export type Request =
+    | InsertRequest
+    | QueryRequest
+    | PurgeRequest
+    | UpdateRequest
+    | SetRequest
+    | GetRequest;
 
 /**
  * Query response

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,16 @@ export enum RequestType {
      * Purge
      */
     Purge = 0x04,
+
+    /**
+     * Set
+     */
+    Set = 0x05,
+
+    /**
+     * Get
+     */
+    Get = 0x06,
 }
 
 /**
@@ -249,14 +259,60 @@ export interface UpdateRequest {
 }
 
 /**
- * Request
+ * Get request
  */
-export type Request = InsertRequest | QueryRequest | PurgeRequest | UpdateRequest;
+export interface GetRequest {
+    /**
+     * Type
+     */
+    type: RequestType.Get;
+
+    /**
+     * Key
+     */
+    key: string;
+}
+
 
 /**
- * Full response
+ * Get request
  */
-export interface FullResponse {
+export interface SetRequest {
+    /**
+     * Type
+     */
+    type: RequestType.Set;
+
+    /**
+     * TTL type
+     */
+    ttl_type: TTLType;
+
+    /**
+     * TTL
+     */
+    ttl: number | bigint;
+
+    /**
+     * Key
+     */
+    key: string;
+
+    /**
+     * Value
+     */
+    value: string;
+}
+
+/**
+ * Request
+ */
+export type Request = InsertRequest | QueryRequest | PurgeRequest | UpdateRequest | SetRequest | GetRequest;
+
+/**
+ * Query response
+ */
+export interface QueryResponse {
     /**
      * Allowed
      */
@@ -279,14 +335,49 @@ export interface FullResponse {
 }
 
 /**
- * Simple response
+ * Get response
  */
-export interface SimpleResponse {
+export interface GetResponse {
+    /**
+     * Allowed
+     */
+    success: boolean;
+
+    /**
+     * TTL type
+     */
+    ttl_type: TTLType;
+
+    /**
+     * TTL remaining
+     */
+    ttl: number | bigint;
+
+    /**
+     * Value
+     */
+    value: string;
+}
+
+/**
+ * Status response
+ */
+export interface StatusResponse {
     /**
      * Success
      */
     success: boolean;
 }
+
+/**
+ * Response types
+ */
+export type ResponseType = 'status' | 'query' | 'get';
+
+/**
+ * Request
+ */
+export type Response = StatusResponse | QueryResponse | GetResponse;
 
 /**
  * Queued request
@@ -302,7 +393,7 @@ export interface QueuedRequest {
      *
      * @param response
      */
-    resolve: (response: FullResponse | SimpleResponse) => void;
+    resolve: (response: Response) => void;
 
     /**
      * Reject
@@ -314,5 +405,5 @@ export interface QueuedRequest {
     /**
      * Expected type
      */
-    expectedType: 'full' | 'simple';
+    expectedType: ResponseType;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -289,6 +289,7 @@ export function parseResponse(
             const length = read(buffer, offset, value_size);
             offset += value_size.valueOf();
             const value = buffer.toString('utf-8', offset);
+            offset += length as number;
 
             return {
                 success: success,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import {Request, Response, RequestType, ResponseType, TTLType, ValueSize, QueryResponse, StatusResponse, GetResponse} from './types';
+import {
+    Request,
+    Response,
+    RequestType,
+    ResponseType,
+    TTLType,
+    ValueSize,
+    QueryResponse,
+    StatusResponse,
+    GetResponse,
+} from './types';
 
 /* c8 ignore start */
 /**
@@ -61,12 +71,7 @@ function writeOnRequest(
  * @param offset
  * @param value_size
  */
-function writeByValue(
-    buffer: Buffer,
-    value: number,
-    offset: number,
-    value_size: ValueSize
-) {
+function writeByValue(buffer: Buffer, value: number, offset: number, value_size: ValueSize) {
     switch (value_size) {
         case ValueSize.UInt64:
             // @ts-ignore
@@ -149,12 +154,12 @@ export function serializeRequest(request: Request, value_size: ValueSize): Buffe
 
             const buffer = Buffer.allocUnsafe(
                 1 + // request_type
-                1 + // ttl_type
-                value_size.valueOf() + // ttl (little endian)
-                1 + // key_size
-                value_size.valueOf() + // value_size
-                keyBuffer.length +
-                valueBuffer.length
+                    1 + // ttl_type
+                    value_size.valueOf() + // ttl (little endian)
+                    1 + // key_size
+                    value_size.valueOf() + // value_size
+                    keyBuffer.length +
+                    valueBuffer.length
             );
 
             let offset = 0;
@@ -238,7 +243,7 @@ export function parseResponse(
     expected: ResponseType,
     value_size: ValueSize
 ): Response {
-    if (expected === "query") {
+    if (expected === 'query') {
         if (buffer.length === 1) {
             return {
                 success: false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,6 +111,7 @@ export function read(buffer: Buffer, offset: number, value_size: ValueSize) {
             return buffer.readUInt8(offset);
     }
 }
+
 /* c8 ignore stop */
 
 /**
@@ -275,33 +276,30 @@ export function parseResponse(
         return {
             success: buffer.readUInt8(0) === 1,
         } as StatusResponse;
+    } else if (buffer.length === 1) {
+        return {
+            success: false,
+            quota: 0,
+            ttl_type: TTLType.Nanoseconds,
+            ttl: 0,
+        };
     } else {
-        if (buffer.length === 1) {
-            return {
-                success: false,
-                quota: 0,
-                ttl_type: TTLType.Nanoseconds,
-                ttl: 0,
-            };
-        } else {
-            let offset = 0;
-            const success = buffer.readUInt8(offset) === 1;
-            offset += 1;
-            const ttl_type = buffer.readUInt8(offset);
-            offset += 1;
-            const ttl = read(buffer, offset, value_size);
-            offset += value_size.valueOf();
-            const length = read(buffer, offset, value_size);
-            offset += value_size.valueOf();
-            const value = buffer.toString('utf-8', offset);
-            offset += length as number;
+        let offset = 0;
+        const success = buffer.readUInt8(offset) === 1;
+        offset += 1;
+        const ttl_type = buffer.readUInt8(offset);
+        offset += 1;
+        const ttl = read(buffer, offset, value_size);
+        offset += value_size.valueOf();
+        read(buffer, offset, value_size);
+        offset += value_size.valueOf();
+        const value = buffer.toString('utf-8', offset);
 
-            return {
-                success: success,
-                ttl_type: ttl_type,
-                ttl: ttl,
-                value: value,
-            } as GetResponse;
-        }
+        return {
+            success: success,
+            ttl_type: ttl_type,
+            ttl: ttl,
+            value: value,
+        } as GetResponse;
     }
 }

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -407,6 +407,16 @@ describe('Service', () => {
         // And that should be fine ...
 
         expect(success_purge.success).toBe(true);
+
+        // After that we're going to check if key has been purged ...
+
+        const check = (await service.send({
+            type: RequestType.Get,
+            key: key,
+        })) as GetResponse;
+
+        expect(typeof check.success).toBe('boolean');
+        expect(check.success).toBe(false);
     });
 
     it('should insert and query multiple keys in a single batch write', async () => {

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -16,14 +16,15 @@
 import {
     AttributeType,
     ChangeType,
-    FullResponse,
+    QueryResponse,
     RequestType,
     Service,
-    SimpleResponse,
+    StatusResponse,
     TTLType,
     ValueSize,
 } from '../src';
-import { expect } from 'vitest';
+import {expect} from 'vitest';
+import {GetResponse} from "../src/types";
 
 describe('Service', () => {
     let service: Service;
@@ -65,7 +66,7 @@ describe('Service', () => {
             quota: flexNumber(isBigInt, 7),
             ttl_type: TTLType.Seconds,
             ttl: flexNumber(isBigInt, 60),
-        })) as SimpleResponse;
+        })) as StatusResponse;
 
         expect(typeof insert.success).toBe('boolean');
 
@@ -78,7 +79,7 @@ describe('Service', () => {
         const first_query = (await service.send({
             type: RequestType.Query,
             key: key,
-        })) as FullResponse;
+        })) as QueryResponse;
 
         expect(typeof first_query.success).toBe('boolean');
         expect(typeof first_query.quota).toMatch(/number|bigint/);
@@ -101,7 +102,7 @@ describe('Service', () => {
             attribute: AttributeType.Quota,
             change: ChangeType.Decrease,
             value: flexNumber(isBigInt, 7),
-        })) as SimpleResponse;
+        })) as StatusResponse;
 
         expect(typeof success_decrease_update.success).toBe('boolean');
 
@@ -117,7 +118,7 @@ describe('Service', () => {
             attribute: AttributeType.Quota,
             change: ChangeType.Decrease,
             value: flexNumber(isBigInt, 7),
-        })) as SimpleResponse;
+        })) as StatusResponse;
 
         expect(typeof failed_decrease_update.success).toBe('boolean');
 
@@ -130,7 +131,7 @@ describe('Service', () => {
         const empty_quota_query = (await service.send({
             type: RequestType.Query,
             key: key,
-        })) as FullResponse;
+        })) as QueryResponse;
 
         expect(typeof empty_quota_query.success).toBe('boolean');
         expect(typeof empty_quota_query.quota).toMatch(/number|bigint/);
@@ -153,7 +154,7 @@ describe('Service', () => {
             attribute: AttributeType.Quota,
             change: ChangeType.Patch,
             value: flexNumber(isBigInt, 10),
-        })) as SimpleResponse;
+        })) as StatusResponse;
 
         expect(typeof success_patch_update.success).toBe('boolean');
 
@@ -166,7 +167,7 @@ describe('Service', () => {
         const patched_quota_query = (await service.send({
             type: RequestType.Query,
             key: key,
-        })) as FullResponse;
+        })) as QueryResponse;
 
         expect(typeof patched_quota_query.success).toBe('boolean');
         expect(typeof patched_quota_query.quota).toMatch(/number|bigint/);
@@ -189,7 +190,7 @@ describe('Service', () => {
             attribute: AttributeType.Quota,
             change: ChangeType.Increase,
             value: flexNumber(isBigInt, 20),
-        })) as SimpleResponse;
+        })) as StatusResponse;
 
         expect(typeof success_increase_update.success).toBe('boolean');
 
@@ -202,7 +203,7 @@ describe('Service', () => {
         const increased_quota_query = (await service.send({
             type: RequestType.Query,
             key: key,
-        })) as FullResponse;
+        })) as QueryResponse;
 
         expect(typeof increased_quota_query.success).toBe('boolean');
         expect(typeof increased_quota_query.quota).toMatch(/number|bigint/);
@@ -225,7 +226,7 @@ describe('Service', () => {
             attribute: AttributeType.TTL,
             change: ChangeType.Increase,
             value: flexNumber(isBigInt, 60),
-        })) as SimpleResponse;
+        })) as StatusResponse;
 
         expect(typeof success_increase_ttl.success).toBe('boolean');
 
@@ -238,7 +239,7 @@ describe('Service', () => {
         const increased_ttl_query = (await service.send({
             type: RequestType.Query,
             key: key,
-        })) as FullResponse;
+        })) as QueryResponse;
 
         expect(typeof increased_ttl_query.success).toBe('boolean');
         expect(typeof increased_ttl_query.quota).toMatch(/number|bigint/);
@@ -261,7 +262,7 @@ describe('Service', () => {
             attribute: AttributeType.TTL,
             change: ChangeType.Decrease,
             value: flexNumber(isBigInt, 60),
-        })) as SimpleResponse;
+        })) as StatusResponse;
 
         expect(typeof success_decrease_ttl.success).toBe('boolean');
 
@@ -274,7 +275,7 @@ describe('Service', () => {
         const decrease_ttl_query = (await service.send({
             type: RequestType.Query,
             key: key,
-        })) as FullResponse;
+        })) as QueryResponse;
 
         expect(typeof decrease_ttl_query.success).toBe('boolean');
         expect(typeof decrease_ttl_query.quota).toMatch(/number|bigint/);
@@ -297,7 +298,7 @@ describe('Service', () => {
             attribute: AttributeType.TTL,
             change: ChangeType.Patch,
             value: flexNumber(isBigInt, 90),
-        })) as SimpleResponse;
+        })) as StatusResponse;
 
         expect(typeof success_patch_ttl.success).toBe('boolean');
 
@@ -310,7 +311,7 @@ describe('Service', () => {
         const patch_ttl_query = (await service.send({
             type: RequestType.Query,
             key: key,
-        })) as FullResponse;
+        })) as QueryResponse;
 
         expect(typeof patch_ttl_query.success).toBe('boolean');
         expect(typeof patch_ttl_query.quota).toMatch(/number|bigint/);
@@ -330,7 +331,7 @@ describe('Service', () => {
         const success_purge = (await service.send({
             type: RequestType.Purge,
             key: key,
-        })) as SimpleResponse;
+        })) as StatusResponse;
 
         expect(typeof success_purge.success).toBe('boolean');
 
@@ -343,7 +344,7 @@ describe('Service', () => {
         const failed_purge = (await service.send({
             type: RequestType.Purge,
             key: key,
-        })) as SimpleResponse;
+        })) as StatusResponse;
 
         expect(typeof failed_purge.success).toBe('boolean');
 
@@ -356,7 +357,7 @@ describe('Service', () => {
         const exists_query = (await service.send({
             type: RequestType.Query,
             key: key,
-        })) as FullResponse;
+        })) as QueryResponse;
 
         expect(typeof exists_query.success).toBe('boolean');
         expect(typeof exists_query.quota).toMatch(/number|bigint/);
@@ -366,6 +367,50 @@ describe('Service', () => {
         // And that should fail ...
 
         expect(exists_query.success).toBe(false);
+    });
+
+    it('should set and get values from the memory', async() => {
+        const key = "in-memory";
+
+        // After that we're going to set something in memory
+
+        const set = (await service.send({
+            type: RequestType.Set,
+            key: key,
+            ttl_type: TTLType.Seconds,
+            ttl: 30,
+            value: "EHLO",
+        })) as StatusResponse;
+
+        expect(set.success).toBe(true);
+
+        // After that we're going to get that key ...
+
+        const get = (await service.send({
+            type: RequestType.Get,
+            key: key,
+        })) as GetResponse;
+
+        expect(typeof get.success).toBe('boolean');
+        expect(typeof get.value).toMatch(/string/);
+        expect(get.value).toBe("EHLO");
+
+        console.log(get);
+
+        // After that we're going to purge the key ...
+
+        const success_purge = (await service.send({
+            type: RequestType.Purge,
+            key: key,
+        })) as StatusResponse;
+
+        console.log(success_purge.success);
+
+        expect(typeof success_purge.success).toBe('boolean');
+
+        // And that should be fine ...
+
+        expect(success_purge.success).toBe(true);
     });
 
     it('should insert and query multiple keys in a single batch write', async () => {
@@ -391,7 +436,7 @@ describe('Service', () => {
                 ttl_type: TTLType.Seconds,
                 ttl: flexNumber(isBigInt, 30),
             },
-        ])) as SimpleResponse[];
+        ])) as StatusResponse[];
 
         expect(res1.success).toBe(true);
         expect(res2.success).toBe(true);
@@ -405,7 +450,7 @@ describe('Service', () => {
                 type: RequestType.Query,
                 key: key2,
             },
-        ])) as FullResponse[];
+        ])) as QueryResponse[];
 
         expect(query1.success).toBe(true);
         expect(query1.quota).toBe(flexNumber(isBigInt, 7));

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -23,8 +23,8 @@ import {
     TTLType,
     ValueSize,
 } from '../src';
-import {expect} from 'vitest';
-import {GetResponse} from "../src/types";
+import { expect } from 'vitest';
+import { GetResponse } from '../src/types';
 
 describe('Service', () => {
     let service: Service;
@@ -369,8 +369,8 @@ describe('Service', () => {
         expect(exists_query.success).toBe(false);
     });
 
-    it('should set and get values from the memory', async() => {
-        const key = "in-memory";
+    it('should set and get values from the memory', async () => {
+        const key = 'in-memory';
 
         // After that we're going to set something in memory
 
@@ -379,7 +379,7 @@ describe('Service', () => {
             key: key,
             ttl_type: TTLType.Seconds,
             ttl: 30,
-            value: "EHLO",
+            value: 'EHLO',
         })) as StatusResponse;
 
         expect(set.success).toBe(true);
@@ -393,7 +393,7 @@ describe('Service', () => {
 
         expect(typeof get.success).toBe('boolean');
         expect(typeof get.value).toMatch(/string/);
-        expect(get.value).toBe("EHLO");
+        expect(get.value).toBe('EHLO');
 
         // After that we're going to purge the key ...
 

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -395,16 +395,12 @@ describe('Service', () => {
         expect(typeof get.value).toMatch(/string/);
         expect(get.value).toBe("EHLO");
 
-        console.log(get);
-
         // After that we're going to purge the key ...
 
         const success_purge = (await service.send({
             type: RequestType.Purge,
             key: key,
         })) as StatusResponse;
-
-        console.log(success_purge.success);
 
         expect(typeof success_purge.success).toBe('boolean');
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -25,10 +25,10 @@ describe('Utils', () => {
         );
     });
 
-    it('should throw error on invalid simple response length', () => {
+    it('should throw error on invalid status response length', () => {
         const invalidBuffer = Buffer.alloc(2); // debería ser 1
-        expect(() => parseResponse(invalidBuffer, 'simple', ValueSize.UInt16)).toThrowError(
-            /Invalid simple response length/
+        expect(() => parseResponse(invalidBuffer, 'status', ValueSize.UInt16)).toThrowError(
+            /Invalid status response length/
         );
     });
 });


### PR DESCRIPTION
This PR includes:

Now we gonna have:

- Better standarization of requests and responses.
- Protocol terms like StatusResponse, QueryResponse and GetResponse instead of SimpleResponde and FullResponse.
- Get and Set requests and responses. This enable lightweight in-memory database.
 
This is not a huge change ... but contains simple breaking changes:

- SimpleResponse now is StatusResponse.
- FullResponse is now QueryResponse. 