### PR TITLE
Sonar pls.

### DIFF
--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -449,6 +449,6 @@ export function HandleInfo(buffer: Buffer): InfoResponse {
         version: buffer
             .subarray(offset + 52 * step, offset + 54 * step) // 416 to 432
             .toString()
-            .replace(/\x00+$/, ''),
+            .replace(/\x00+$/, ''), // NOSONAR
     };
 }


### PR DESCRIPTION
This is a "security concern". My advice is simple, throttr SDK must be used on internal networks, i mean, not exposed.

I add the Sonar related comment:

```
Most of the regular expression engines use backtracking to try all possible execution paths of the regular expression when evaluating an input, in some cases it can cause performance issues, called catastrophic backtracking situations. In the worst case, the complexity of the regular expression is exponential in the size of the input, this means that a small carefully-crafted input (like 20 chars) can trigger catastrophic backtracking and cause a denial of service of the application. Super-linear regex complexity can lead to the same impact too with, in this case, a large carefully-crafted input (thousands chars).

This rule determines the runtime complexity of a regular expression and informs you if it is not linear. 
```

This code will be executed to remove zeroes of instance version. (over fixed 16 bytes).

If you think about, this will be executed on `throttr` response parse context. Which is, again, fixed and static protocol. There are no reason to believe in this issue.