### PR TITLE
Compatible with throttr v5.0.6.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
         services:
             throttr:
-                image: ghcr.io/throttr/throttr:5.0.5-debug-${{ matrix.size }}-AMD64-metrics-enabled
+                image: ghcr.io/throttr/throttr:5.0.6-debug-${{ matrix.size }}-AMD64-metrics-enabled
                 ports:
                     - 9000:9000
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@throttr/sdk",
-    "version": "5.1.1",
+    "version": "5.1.2",
     "description": "Throttr SDK for Node.js",
     "main": "dist/src/index.js",
     "types": "dist/src/index.d.ts",


### PR DESCRIPTION
This isn't a breaking change. It's something different.

Throttr v5.0.5 uses steady_clock (relative clock) instead of system_clock (realistic clock).

If you see the LIST response, you'll check that the expired_at isn't a value that you can handle.

Right now you'll get a nanosecond - unix timestamp.