### PR TITLE
Pubsub only on specific connection, connection id and throttr server version bump.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
         services:
             throttr:
-                image: ghcr.io/throttr/throttr:5.0.6-debug-${{ matrix.size }}-AMD64-metrics-enabled
+                image: ghcr.io/throttr/throttr:5.0.7-debug-${{ matrix.size }}-AMD64-metrics-enabled
                 ports:
                     - 9000:9000
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@throttr/sdk",
-    "version": "5.1.4",
+    "version": "5.1.5",
     "description": "Throttr SDK for Node.js",
     "main": "dist/src/index.js",
     "types": "dist/src/index.d.ts",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -22,7 +22,8 @@ import {
     Response,
     ResponseType,
     RoundStatus,
-    ValueSize, WhoAmIResponse,
+    ValueSize,
+    WhoAmIResponse,
 } from './types';
 import { BuildRequest, GetExpectedResponseType, ParseResponse } from './protocol';
 import { read } from './utils';
@@ -81,7 +82,7 @@ export class Connection {
     /**
      * ID
      */
-    public id: string = "";
+    public id: string = '';
 
     /**
      * Constructor
@@ -156,8 +157,8 @@ export class Connection {
         /* c8 ignore stop */
 
         if (this.alive && this.socket.writable) {
-            const response = await (this.send({
-                type: RequestType.WhoAmI
+            const response = (await this.send({
+                type: RequestType.WhoAmI,
             })) as WhoAmIResponse;
 
             this.id = response.id;
@@ -191,13 +192,13 @@ export class Connection {
 
         const expectedTypes = requests.map(req => GetExpectedResponseType(req));
 
-        requests.forEach((req) => {
+        requests.forEach(req => {
             if (req.type == RequestType.Subscribe) {
                 this.subscriptions.set(req.channel, req.callback);
             } else if (req.type == RequestType.Unsubscribe) {
                 this.subscriptions.delete(req.channel);
             }
-        })
+        });
 
         return new Promise((resolve, reject) => {
             // We gonna to define an array of responses

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -15,15 +15,16 @@
 
 import { Socket } from 'net';
 import {
+    Configuration,
+    QueuedRequest,
     Request,
+    RequestType,
     Response,
     ResponseType,
-    QueuedRequest,
-    Configuration,
-    ValueSize,
     RoundStatus,
+    ValueSize, WhoAmIResponse,
 } from './types';
-import { BuildRequest, ParseResponse, GetExpectedResponseType } from './protocol';
+import { BuildRequest, GetExpectedResponseType, ParseResponse } from './protocol';
 import { read } from './utils';
 
 /**
@@ -78,6 +79,11 @@ export class Connection {
     public subscriptions: Map<string, (data: string) => void> = new Map();
 
     /**
+     * ID
+     */
+    public id: string = "";
+
+    /**
      * Constructor
      *
      * @param config
@@ -116,7 +122,7 @@ export class Connection {
             // Find info about the TCP errors on connection ...
 
             // We are going to try to connect.
-            this.socket.connect(this.config.port, this.config.host, () => {
+            this.socket.connect(this.config.port, this.config.host, async () => {
                 // We bind data event to the onData handler.
                 this.socket.on('data', chunk => this.onData(chunk));
                 // We bind error event to the OnError handler.
@@ -126,7 +132,7 @@ export class Connection {
                 this.alive = true;
 
                 // We are going to wait until we have a writable socket.
-                this.waitUntilReachConnectedStatus(resolve, reject);
+                await this.waitUntilReachConnectedStatus(resolve, reject);
             });
         });
     }
@@ -137,7 +143,7 @@ export class Connection {
      * @param resolve
      * @param reject
      */
-    waitUntilReachConnectedStatus(resolve: any, reject: any) {
+    async waitUntilReachConnectedStatus(resolve: any, reject: any) {
         /* c8 ignore start */
         // You have at least X attempts
         const max_attempts =
@@ -150,6 +156,12 @@ export class Connection {
         /* c8 ignore stop */
 
         if (this.alive && this.socket.writable) {
+            const response = await (this.send({
+                type: RequestType.WhoAmI
+            })) as WhoAmIResponse;
+
+            this.id = response.id;
+
             resolve();
             /* c8 ignore start */
         } else if (
@@ -178,6 +190,14 @@ export class Connection {
         const buffers = requests.map(req => BuildRequest(req, this.config.value_size));
 
         const expectedTypes = requests.map(req => GetExpectedResponseType(req));
+
+        requests.forEach((req) => {
+            if (req.type == RequestType.Subscribe) {
+                this.subscriptions.set(req.channel, req.callback);
+            } else if (req.type == RequestType.Unsubscribe) {
+                this.subscriptions.delete(req.channel);
+            }
+        })
 
         return new Promise((resolve, reject) => {
             // We gonna to define an array of responses

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -423,21 +423,37 @@ export function HandleInfo(buffer: Buffer): InfoResponse {
         total_stat_requests: Number(read(buffer, offset + 21 * step, ValueSize.UInt64)),
         total_stat_requests_per_minute: Number(read(buffer, offset + 22 * step, ValueSize.UInt64)),
         total_subscribe_requests: Number(read(buffer, offset + 23 * step, ValueSize.UInt64)),
-        total_subscribe_requests_per_minute: Number(read(buffer, offset + 24 * step, ValueSize.UInt64)),
+        total_subscribe_requests_per_minute: Number(
+            read(buffer, offset + 24 * step, ValueSize.UInt64)
+        ),
         total_unsubscribe_requests: Number(read(buffer, offset + 25 * step, ValueSize.UInt64)),
-        total_unsubscribe_requests_per_minute: Number(read(buffer, offset + 26 * step, ValueSize.UInt64)),
+        total_unsubscribe_requests_per_minute: Number(
+            read(buffer, offset + 26 * step, ValueSize.UInt64)
+        ),
         total_publish_requests: Number(read(buffer, offset + 27 * step, ValueSize.UInt64)),
-        total_publish_requests_per_minute: Number(read(buffer, offset + 28 * step, ValueSize.UInt64)),
+        total_publish_requests_per_minute: Number(
+            read(buffer, offset + 28 * step, ValueSize.UInt64)
+        ),
         total_channel_requests: Number(read(buffer, offset + 29 * step, ValueSize.UInt64)),
-        total_channel_requests_per_minute: Number(read(buffer, offset + 30 * step, ValueSize.UInt64)),
+        total_channel_requests_per_minute: Number(
+            read(buffer, offset + 30 * step, ValueSize.UInt64)
+        ),
         total_channels_requests: Number(read(buffer, offset + 31 * step, ValueSize.UInt64)),
-        total_channels_requests_per_minute: Number(read(buffer, offset + 32 * step, ValueSize.UInt64)),
+        total_channels_requests_per_minute: Number(
+            read(buffer, offset + 32 * step, ValueSize.UInt64)
+        ),
         total_whoami_requests: Number(read(buffer, offset + 33 * step, ValueSize.UInt64)),
-        total_whoami_requests_per_minute: Number(read(buffer, offset + 34 * step, ValueSize.UInt64)),
+        total_whoami_requests_per_minute: Number(
+            read(buffer, offset + 34 * step, ValueSize.UInt64)
+        ),
         total_connection_requests: Number(read(buffer, offset + 35 * step, ValueSize.UInt64)),
-        total_connection_requests_per_minute: Number(read(buffer, offset + 36 * step, ValueSize.UInt64)),
+        total_connection_requests_per_minute: Number(
+            read(buffer, offset + 36 * step, ValueSize.UInt64)
+        ),
         total_connections_requests: Number(read(buffer, offset + 37 * step, ValueSize.UInt64)),
-        total_connections_requests_per_minute: Number(read(buffer, offset + 38 * step, ValueSize.UInt64)),
+        total_connections_requests_per_minute: Number(
+            read(buffer, offset + 38 * step, ValueSize.UInt64)
+        ),
         total_read_bytes: Number(read(buffer, offset + 39 * step, ValueSize.UInt64)),
         total_read_bytes_per_minute: Number(read(buffer, offset + 40 * step, ValueSize.UInt64)),
         total_write_bytes: Number(read(buffer, offset + 41 * step, ValueSize.UInt64)),
@@ -445,8 +461,12 @@ export function HandleInfo(buffer: Buffer): InfoResponse {
         total_keys: Number(read(buffer, offset + 43 * step, ValueSize.UInt64)),
         total_counters: Number(read(buffer, offset + 44 * step, ValueSize.UInt64)),
         total_buffers: Number(read(buffer, offset + 45 * step, ValueSize.UInt64)),
-        total_allocated_bytes_on_counters: Number(read(buffer, offset + 46 * step, ValueSize.UInt64)),
-        total_allocated_bytes_on_buffers: Number(read(buffer, offset + 47 * step, ValueSize.UInt64)),
+        total_allocated_bytes_on_counters: Number(
+            read(buffer, offset + 46 * step, ValueSize.UInt64)
+        ),
+        total_allocated_bytes_on_buffers: Number(
+            read(buffer, offset + 47 * step, ValueSize.UInt64)
+        ),
         total_subscriptions: Number(read(buffer, offset + 48 * step, ValueSize.UInt64)),
         total_channels: Number(read(buffer, offset + 49 * step, ValueSize.UInt64)),
         startup_timestamp: Number(read(buffer, offset + 50 * step, ValueSize.UInt64)),

--- a/src/service.ts
+++ b/src/service.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-import { Configuration, Request, RequestType, Response } from './types';
+import { Configuration, Request, Response } from './types';
 import { Connection } from './connection';
 
 /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -83,25 +83,8 @@ export class Service {
         }
         /* c8 ignore stop */
 
-        if (
-            !(request instanceof Array) &&
-            (request.type === RequestType.Subscribe || request.type === RequestType.Unsubscribe)
-        ) {
-            const promises = [] as Response[];
-            for (const item of this.connections) {
-                if (request.type == RequestType.Subscribe) {
-                    item.subscriptions.set(request.channel, request.callback);
-                } else {
-                    item.subscriptions.delete(request.channel);
-                }
-                const promise = (await item.send(request)) as Response;
-                promises.push(promise);
-            }
-            return promises;
-        } else {
-            const connection = await this.getConnection();
-            return connection.send(request);
-        }
+        const connection = await this.getConnection();
+        return connection.send(request);
     }
 
     /**
@@ -109,7 +92,7 @@ export class Service {
      *
      * @private
      */
-    private async getConnection(): Promise<Connection> {
+    public async getConnection(): Promise<Connection> {
         for (let i = 0; i < this.connections.length; i++) { // NOSONAR
             const index = this.round_robin_index;
             this.round_robin_index = (this.round_robin_index + 1) % this.connections.length;

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -543,17 +543,17 @@ describe('Service', () => {
         expect(stats.keys[0].total_writes).toBeGreaterThanOrEqual(0);
         expect(stats.keys[1].total_writes).toBeGreaterThanOrEqual(0);
 
-        const subscribe = (await service.send({
+        const connection_item = await service.getConnection();
+
+        const subscribe = (await connection_item.send({
             type: RequestType.Subscribe,
             channel: 'my-channel',
             callback: (data: string) => {
                 expect(data).toBe('EHLO');
             },
-        })) as StatusResponse[];
+        })) as StatusResponse;
         //
-        subscribe.forEach((status: StatusResponse) => {
-            expect(status.success).toBe(true);
-        });
+        expect(subscribe.success).toBe(true);
 
         const success_publish = (await service.send({
             type: RequestType.Publish,
@@ -563,14 +563,12 @@ describe('Service', () => {
 
         expect(success_publish.success).toBe(true);
 
-        const unsubscribe = (await service.send({
+        const unsubscribe = (await connection_item.send({
             type: RequestType.Unsubscribe,
             channel: 'my-channel',
-        })) as StatusResponse[];
+        })) as StatusResponse;
 
-        unsubscribe.forEach((status: StatusResponse) => {
-            expect(status.success).toBe(true);
-        });
+        expect(unsubscribe.success).toBe(true);
 
         const failed_publish = (await service.send({
             type: RequestType.Publish,


### PR DESCRIPTION
This patch include three things:

1. Subscribe and unsubscribe must be done per connection:

```typescript
const connection = await service.getConnection();
await connection.send({ 
    type: RequestType.Subscribe,
    channel: "abc",
    callback: (message: string) => console.log(message)
}
```

> This resolve the problem at unsubscribe ...

```typescript
await service.send({ 
    type: RequestType.Unsubscribe,
    channel: "abc"
}
// But subscription are per connection, which one?
```

Right way:

```typescript
const connection = await service.getConnection();
await connection.send({ 
    type: RequestType.Subscribe,
    channel: "abc",
    ...
}

// Time to unsubscribe ...
await connection.send({ 
    type: RequestType.Unsubscribe,
    channel: "abc"
}
// This one.
```

2. Connections now recover his connection id by doing WHOAMI request after connection stablished.
3. SDK is marked as compatible with 5.0.7.