### PR TITLE
Unix socket domain added.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@throttr/sdk",
-    "version": "5.1.6",
+    "version": "5.1.7",
     "description": "Throttr SDK for Node.js",
     "main": "dist/src/index.js",
     "types": "dist/src/index.d.ts",

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -123,7 +123,7 @@ export class Connection {
             // Find info about the TCP errors on connection ...
 
             // We are going to try to connect.
-            this.socket.connect(this.config.port, this.config.host, async () => {
+            const on_connect = async () =>  {
                 // We bind data event to the onData handler.
                 this.socket.on('data', chunk => this.onData(chunk));
                 // We bind error event to the OnError handler.
@@ -134,7 +134,15 @@ export class Connection {
 
                 // We are going to wait until we have a writable socket.
                 await this.waitUntilReachConnectedStatus(resolve, reject);
-            });
+            }
+
+            /* c8 ignore start */
+            if (this.config.socket) {
+                this.socket.connect(this.config.socket, on_connect);
+            } else {
+                this.socket.connect(this.config.port, this.config.host, on_connect);
+            }
+            /* c8 ignore stop */
         });
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,16 @@ export interface Configuration {
      * Connection configuration
      */
     connection_configuration?: ConnectionConfiguration;
+
+    /**
+     * Is unix
+     */
+    use_uds?: boolean;
+
+    /**
+     * Socket
+     */
+    socket?: string;
 }
 
 /**


### PR DESCRIPTION
Now you can use UDS.

Consider the following:

- TCP have some overhead, syscalls and more (like headers and fragmentation).
- UDS is the most efficient and direct IPC without process shared memory.

In other words, the cost of use Throttr with Unix Sockets is lowest than using TCP. 

How much? Just use google and what gemini says, or stackoverflow.

Anyways, this isn't a breacking change but will be considered as new low version.